### PR TITLE
Allows soft-deletion of comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,6 +5,14 @@ class CommentsController < ApplicationController
     redirect_to :back
   end
 
+  # Soft-deletes a comment, rather than outright destroying it
+  def destroy
+    Comment.find(params[:id]).soft_delete
+    flash[:notice] = 'Comment deleted.  Do note that its still in our '\
+      'system, but other users can\'t read it'
+    redirect_to :back
+  end
+
   private
 
   def comment_params

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,4 +5,12 @@ class Comment < ActiveRecord::Base
   validates_presence_of :body
 
   has_many :comments, as: :parent
+
+  def soft_deleted?
+    !!soft_deleted
+  end
+
+  def soft_delete
+    update_attribute(:soft_deleted, true)
+  end
 end

--- a/app/views/posts/_comments_list.html.erb
+++ b/app/views/posts/_comments_list.html.erb
@@ -7,8 +7,15 @@
   <% parent.comments.select(&:persisted?).each do |comment| %>
     <div class="comment">
       <div class="body">
-        <%= comment.body %>
+        <% if comment.soft_deleted? %>
+          [deleted]
+        <% else %>
+          <%= comment.body %>
+        <% end %>
       </div>
+      <% unless comment.soft_deleted? %>
+        <%= link_to 'Delete', comment_path(comment), method: :delete %>
+      <% end %>
       <%= render 'comments_list', parent: comment, toplevel: false %>
     </div>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root 'home#index'
   resources :posts
-  resources :comments, only: :create
+  resources :comments, only: [:create, :destroy]
 
   devise_for :users
 end

--- a/db/migrate/20150727201742_add_soft_deletion_to_comments.rb
+++ b/db/migrate/20150727201742_add_soft_deletion_to_comments.rb
@@ -1,0 +1,5 @@
+class AddSoftDeletionToComments < ActiveRecord::Migration
+  def change
+    add_column :comments, :soft_deleted, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150726211124) do
+ActiveRecord::Schema.define(version: 20150727201742) do
 
   create_table "comments", force: :cascade do |t|
     t.integer  "parent_id"
     t.string   "parent_type"
     t.integer  "author_id"
     t.text     "body"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.boolean  "soft_deleted", default: false
   end
 
   create_table "posts", force: :cascade do |t|

--- a/spec/features/delete_comment_spec.rb
+++ b/spec/features/delete_comment_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'deleting a comment' do
+  let(:post) { create(:post) }
+  let!(:comment) { create(:comment, parent: post) }
+
+  before do
+    visit post_path(post)
+    click_link 'Delete'
+  end
+
+  it 'marks the comment as deleted' do
+    expect(comment.reload).to be_soft_deleted
+  end
+
+  it 'does not render the comment on the post page' do
+    expect(page).not_to have_content(comment.body)
+  end
+end


### PR DESCRIPTION
# Why?

Users should be able to soft delete any comment
# What changed?
- Adds soft_deleted boolean to comments table to determine if a comment has been soft deleted
- Display [deleted] instead of comment body if its been deleted
